### PR TITLE
Fix for bug with multi-node stats on 7.2 clusters

### DIFF
--- a/isi_data_insights_daemon.py
+++ b/isi_data_insights_daemon.py
@@ -216,7 +216,7 @@ class IsiDataInsightsDaemon(run.RunDaemon):
                     results = []
                     for stat in stats:
                         result = stats_client.query_stat(stat)
-                        results.append(result)
+                        results.extend(result)
 
             except cluster.isi_sdk.rest.ApiException as exc:
                 LOG.error("Failed to query stats from cluster %s, exception "\

--- a/isi_stats_client.py
+++ b/isi_stats_client.py
@@ -111,7 +111,7 @@ class IsiStatsClient(object):
                         expand_clientid=expand_clientid,
                         timeout=timeout)
 
-        return query_result.stats[0]
+        return query_result.stats
 
 
     def get_stats_metadata(self, stats=None):


### PR DESCRIPTION
This fixes an issue where 7.2 clusters were only having the first node
of the cluster's stats inserted into the database.