### PR TITLE
Updated daemons package to be 1.3.0 or higher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-daemons >= 1.2.2
+daemons >= 1.3.0
 influxdb >= 2.12.0
 pip >= 8.0.2
 urllib3 >= 1.13.1


### PR DESCRIPTION
The newer version of daemons stores the actual pid of the daemon in the pid file and uses it to verify if the daemon is actually running. As opposed to before where it just assumed that if the pid file existed then the daemon was running.