### PR TITLE
Fix cluster specific tags getting polluted by node tags

### DIFF
--- a/influxdb_plugin.py
+++ b/influxdb_plugin.py
@@ -76,11 +76,11 @@ def process(cluster, stats):
     InfluxDB service. Organize the measurements by cluster and node via tags.
     """
     LOG.debug("Processing stats %d.", len(stats))
-    tags = {"cluster": cluster}
     influxdb_points = []
     num_points = 0
     points_written = 0
     for stat in stats:
+        tags = {"cluster": cluster}
         if stat.devid != 0:
             tags["node"] = stat.devid
         # check if the stat query returned an error


### PR DESCRIPTION
The tags dictionary is created and reused for every stat, so if it starts with node specific stats and then does cluster specific stats then the cluster specific stats will inadvertently get tagged with the last node tag.