### PR TITLE
Changed op_count to op_rate in NFSv3 and SMB2 Ops/s stat views

### DIFF
--- a/grafana_cluster_list_dashboard.json
+++ b/grafana_cluster_list_dashboard.json
@@ -954,7 +954,7 @@
                 [
                   {
                     "params": [
-                      "op_count"
+                      "op_rate"
                     ],
                     "type": "field"
                   },
@@ -1334,7 +1334,7 @@
                 [
                   {
                     "params": [
-                      "op_count"
+                      "op_rate"
                     ],
                     "type": "field"
                   },


### PR DESCRIPTION
The Op/s stat is supposed to display the op_rate not the op_count, this change fixes that.