### PR TITLE
Added cluster composite, equation, and pct change stats.

### DIFF
--- a/example_isi_data_insights_d.cfg
+++ b/example_isi_data_insights_d.cfg
@@ -181,3 +181,70 @@ stats: node.ifs.heat.lock.total
   node.ifs.heat.unlink.total
   node.ifs.heat.getattr.total
   node.ifs.heat.setattr.total
+
+# These stats are not currently active by default. They are here to serve as an example of how to use the
+# derived stats functionality. See the comments below for more details.
+[concurrency_stats]
+update_interval: *
+stats: node.ifs.ops.in node.ifs.ops.out node.disk.iosched.latency.avg
+  cluster.protostats.nfs.total
+  cluster.protostats.nfs.total
+  cluster.protostats.smb2.total
+  cluster.protostats.nlm.total
+  cluster.protostats.cifs.total
+  cluster.protostats.http.total
+  cluster.protostats.siq.total
+  cluster.protostats.nfs4.total
+  cluster.protostats.hdfs.total
+  cluster.protostats.ftp.total
+# The composite_stats, equation_stats, percent_change_stats, final_equation_stats sections allow you to
+# specify new stats that are derived from the values of other stats. You can derive stats from base stats
+# or even specific fields or indices within a base stat's value, which is actually required if the
+# base stat's value is not a float or integer (i.e. it is a dict or list). See below for more
+# info on each type of derived stat.
+
+#### Composite Stats Description #####
+# The composite_stats parameter specifies a list of node specific stats (i.e. stats whose name
+# start with "node.") where each stat is composited across the entire cluster using the specified
+# operation. Supported operations at this time are avg, max, min, and sum.
+# The output name of a composite_stat is: cluster.<name of original stat>.[<field1>[...<fieldN>]].<name of operation>,
+# so for the three stats above it would be cluster.node.ifs.ops.in.sum,
+# cluster.node.ifs.ops.out.sum, and cluster.node.disk.iosched.latency.avg.avg. If the base stat
+# contains one of more fields then those are appended to the name with '.' as delimiter, e.g.:
+# sum(node.protostats.nfs.total:op_count) -> cluster.node.protostats.nfs.total.op_count.sum
+composite_stats: sum(node.ifs.ops.in) sum(node.ifs.ops.out) avg(node.disk.iosched.latency.avg)
+
+
+#### Equation Stats Description #####
+# The equation_stats parameter specifies a list of output stat names for stats that will be
+# derived from an equation that takes as input either base stat values or composite_stats values.
+# The equation for each equation stat is specified in a parameter named the same as the equation
+# stat.
+equation_stats: cluster.ifs.concurrency cluster.protostats.all.total.op_count cluster.protostats.all.total.time_avg
+# This is the definition of the equation used to compute the the cluster.ifs.concurrency stat.
+# Any of the base stats or any composite stat can be used in the equation expression. Any
+# expression supported by the Equation package of Python can be used:
+# https://pypi.python.org/pypi/Equation
+cluster.ifs.concurrency: (cluster.node.ifs.ops.in.sum + cluster.node.ifs.ops.out.sum) * cluster.node.disk.iosched.latency.avg.avg
+# The cluster.protostats.all.total.op_count is a sum of all 9 of the different protocols' op_count.
+# This equation shows an example of how to select a specific field within a stat that returns a dict, in this case the op_count
+# field. Note that some stats are returned as list with always only a single dict item - in those cases the value is treated
+# as if it was just a dict. Otherwise, to index into a list you would use numeric field names after the colon. Multiple field
+# names or list indices are allowed (i.e. node.example.stat:field1:field2:field3...).
+cluster.protostats.all.total.op_count: cluster.protostats.nfs.total:op_count + cluster.protostats.nfs.total:op_count + cluster.protostats.smb2.total:op_count + cluster.protostats.nlm.total:op_count + cluster.protostats.cifs.total:op_count + cluster.protostats.http.total:op_count + cluster.protostats.siq.total:op_count + cluster.protostats.nfs4.total:op_count + cluster.protostats.hdfs.total:op_count + cluster.protostats.ftp.total:op_count
+# This stat computes the sum of the time_avg field and then takes an average.
+cluster.protostats.all.total.time_avg: (cluster.protostats.nfs.total:time_avg + cluster.protostats.nfs.total:time_avg + cluster.protostats.smb2.total:time_avg + cluster.protostats.nlm.total:time_avg + cluster.protostats.cifs.total:time_avg + cluster.protostats.http.total:time_avg + cluster.protostats.siq.total:time_avg + cluster.protostats.nfs4.total:time_avg + cluster.protostats.hdfs.total:time_avg + cluster.protostats.ftp.total:time_avg) / 10.0
+
+#### Percent Change Stats Description #####
+# The percent_change_stats section specifies a list of base stats, composite stats, and/or equation
+# stats whose percent change from one measurement to the next will be stored in a new stat whose
+# name will be <name of original stat>.percentchange
+percent_change_stats: cluster.node.disk.iosched.latency.avg.avg cluster.protostats.all.total.time_avg
+
+#### Final Equation Stats Description #####
+# The final_equation_stats is the same as the equation_stats section except these equations have access to base stats and all of the previously
+# defined derived stats as input. Again list the names of the output stats and then list the equation for each output stat in section of that same
+# name.
+final_equation_stats: cluster.ifs.concurrency.importance
+# Definition of the cluster.ifs.concurrency.importance final equation stat
+cluster.ifs.concurrency.importance: (cluster.protostats.all.total.op_count * cluster.protostats.all.total.time_avg) * cluster.node.disk.iosched.latency.avg.avg.percentchange

--- a/grafana_cluster_concurrency_dashboard.json
+++ b/grafana_cluster_concurrency_dashboard.json
@@ -1,0 +1,2201 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_LOCAL_INFLUXDB",
+      "label": "Local influxdb",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    }
+  ],
+  "id": null,
+  "title": "Isilon Data Insights Cluster Concurrency",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "sharedCrosshair": false,
+  "hideControls": false,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "now": true,
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "allFormat": "regex values",
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_LOCAL_INFLUXDB}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "multiFormat": "glob",
+        "name": "cluster",
+        "options": [],
+        "query": "show tag values with key = \"cluster\"",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": null,
+        "tagsQuery": null,
+        "type": "query"
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": "30s",
+  "schemaVersion": 13,
+  "version": 2,
+  "links": [],
+  "gnetId": null,
+  "rows": [
+    {
+      "title": "Welcome to the Isilon Detail Dashboard for $cluster",
+      "panels": [
+        {
+          "content": "* Use the pull down at the very top left of the page (next to the spiral icon) to select which dashboard you want to look at.\n* Use the cluster and other pull downs to select the cluster and protocol of interest.\n* Use highlight with your mouse the time period you want to zoom into or use the pull downs at the top right to select specific time periods.\n* Note that by default the dates and time displayed are in your browser’s time zone, not the source cluster.   You can get it to display in UTC via the settings under the little gear symbol at the top of the page.\n* You can hide rows using the green slide-out tab to the left of each chart.\n* If there is a legend displayed you can click on elements within it to hide or display items, etc.\n* Click on the title of the chart and then the horizontal bars icon at the left to show/hide the legend and get a CSV export of the data.\n* There is no significance in whether things are displayed as lines, bars or points - we have used whatever seems to be clearest for the data.\n",
+          "editable": true,
+          "error": false,
+          "id": 18,
+          "links": [],
+          "mode": "markdown",
+          "span": 12,
+          "title": "Welcome to the Isilon Detail Dashboard for $cluster",
+          "transparent": true,
+          "type": "text"
+        }
+      ],
+      "showTitle": false,
+      "titleSize": "h6",
+      "height": "250px",
+      "repeat": null,
+      "repeatRowId": null,
+      "repeatIteration": null,
+      "collapse": false
+    },
+    {
+      "title": "Cluster Status",
+      "panels": [
+        {
+          "content": "<a target=\"_blank\" href=\"https://$cluster:8080/\">WebUI  for $cluster</a><br>\n<a href=/dashboard/db/isilon-data-insights-cluster-summary>Cluster list</a>\n",
+          "editable": true,
+          "error": false,
+          "id": 22,
+          "links": [
+            {
+              "dashboard": "",
+              "targetBlank": true,
+              "title": "WebUI",
+              "type": "absolute",
+              "url": "https://$cluster:8080/"
+            }
+          ],
+          "mode": "html",
+          "span": 1,
+          "title": "$cluster",
+          "type": "text"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 32,
+          "interval": null,
+          "links": [
+            {
+              "dashboard": "https://$cluster:8080/",
+              "targetBlank": true,
+              "title": "WebUI for $cluster",
+              "type": "absolute",
+              "url": "https://$cluster:8080/"
+            }
+          ],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.count.all",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "1,2",
+          "title": "Total Nodes",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "",
+              "value": ""
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 13,
+          "interval": null,
+          "links": [
+            {
+              "dashboard": "https://$cluster:8080/",
+              "targetBlank": true,
+              "title": "WebUI for $cluster",
+              "type": "absolute",
+              "url": "https://$cluster:8080/"
+            }
+          ],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.count.down",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "1,2",
+          "title": "Nodes Down",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "",
+              "value": ""
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 14,
+          "interval": null,
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "WebUI for $cluster",
+              "type": "absolute",
+              "url": "https://$cluster:8080/"
+            }
+          ],
+          "mappingType": 2,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "0",
+              "text": "Healthy",
+              "to": "0"
+            },
+            {
+              "from": ".0001",
+              "text": "Attention",
+              "to": "1.999"
+            },
+            {
+              "from": "2",
+              "text": "Down",
+              "to": "5"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.health",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "0.0001,2",
+          "title": "Alert Status",
+          "transparent": false,
+          "type": "singlestat",
+          "valueFontSize": "50%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "Healthy",
+              "value": "0"
+            },
+            {
+              "op": "=",
+              "text": "Attention",
+              "value": "1"
+            },
+            {
+              "op": "=",
+              "text": "Down",
+              "value": "2"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 1,
+            "minValue": 0,
+            "show": true,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 8,
+          "interval": null,
+          "links": [],
+          "mappingType": 2,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.cpu.idle.avg",
+              "policy": "default",
+              "query": "SELECT 1.0 - mean(\"value\")  / 1000 FROM \"cluster.cpu.idle.avg\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      " / 1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "0.80,0.95",
+          "title": "Cluster CPU",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "percent",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": true,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 9,
+          "interval": null,
+          "links": [],
+          "mappingType": 2,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "ifs.percent.used",
+              "policy": "default",
+              "query": "SELECT 100.0 - mean(\"value\") FROM \"ifs.percent.avail\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "80,90",
+          "title": "Cluster Capacity Utilization",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "Bps",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 33,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.protostats.nfs.total_time_avg",
+              "policy": "default",
+              "query": "SELECT mean(\"in_rate\") + mean(\"out_rate\") FROM \"cluster.protostats.nfs.total\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      "/1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "10,25",
+          "title": "NFSv3 Throughput",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "ops",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 20,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.protostats.nfs.total_time_avg",
+              "policy": "default",
+              "query": "SELECT mean(\"op_rate\") FROM \"cluster.protostats.nfs.total\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      "/1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "10,25",
+          "title": "NFSv3 Op/s",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 23,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.protostats.nfs.total_time_avg",
+              "policy": "default",
+              "query": "SELECT mean(\"time_avg\") /1000 FROM \"cluster.protostats.nfs.total\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      "/1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "10,25",
+          "title": "NFSv3 Latency",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "Bps",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 34,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.protostats.nfs.total_time_avg",
+              "policy": "default",
+              "query": "SELECT mean(\"in_rate\") + mean(\"out_rate\") FROM \"cluster.protostats.smb2.total\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      "/1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "10,25",
+          "title": "SMB2 Throughput",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "ops",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 21,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.protostats.nfs.total_time_avg",
+              "policy": "default",
+              "query": "SELECT mean(\"op_rate\") FROM \"cluster.protostats.smb2.total\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      "/1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "10,25",
+          "title": "SMB2 Op/s",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 24,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 1,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.protostats.nfs.total_time_avg",
+              "policy": "default",
+              "query": "SELECT mean(\"time_avg\") /1000 FROM \"cluster.protostats.smb2.total\" WHERE \"cluster\" =~ /^$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      "/1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": "10,25",
+          "title": "SMB2 Latency",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "showTitle": false,
+      "titleSize": "h6",
+      "height": "150px",
+      "repeat": null,
+      "repeatRowId": null,
+      "repeatIteration": null,
+      "collapse": false
+    },
+    {
+      "title": "Dashboard Row",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "id": 36,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Cluster Average Disk Latency Percent Change",
+              "yaxis": 2
+            }
+          ],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "IFS Concurrency",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.ifs.concurrency",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            },
+            {
+              "alias": "Cluster Average Disk Latency Percent Change",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.disk.iosched.latency.avg.avg.percentchange",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Cluster IFS Concurrency",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "-15000",
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": false,
+      "titleSize": "h6",
+      "height": 250,
+      "repeat": null,
+      "repeatRowId": null,
+      "repeatIteration": null,
+      "collapse": false
+    },
+    {
+      "title": "Dashboard Row",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "id": 37,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "alias": "Cluster Average Disk Latency",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.disk.iosched.latency.avg.avg",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            },
+            {
+              "alias": "Node $tag_node Average Disk Latency",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "node"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "node.disk.iosched.latency.avg",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk Latency",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "id": 38,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Cluster Average Disk Latency Percent Change",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.disk.iosched.latency.avg.avg.percentchange",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Cluster Average Disk Latency Percent Change",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": false,
+      "titleSize": "h6",
+      "height": 250,
+      "repeat": null,
+      "repeatRowId": null,
+      "repeatIteration": null,
+      "collapse": false
+    },
+    {
+      "title": "Dashboard Row",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_LOCAL_INFLUXDB}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "id": 39,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Cluster IFS Input OPs Count",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.ifs.ops.in.sum",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            },
+            {
+              "alias": "Cluster IFS Output OPs Count",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cluster.node.ifs.ops.out.sum",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            },
+            {
+              "alias": "Node $tag_node IFS Input OPs Count",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "node"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "node.ifs.ops.in",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            },
+            {
+              "alias": "Node $tag_node IFS Output OPs Count",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "node"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "node.ifs.ops.out",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cluster",
+                  "operator": "=~",
+                  "value": "/^$cluster$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "IFS OP Counts",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "showTitle": false,
+      "titleSize": "h6",
+      "height": 250,
+      "repeat": null,
+      "repeatRowId": null,
+      "repeatIteration": null,
+      "collapse": false
+    }
+  ]
+}

--- a/isi_data_insights_daemon.py
+++ b/isi_data_insights_daemon.py
@@ -1,4 +1,5 @@
 from daemons.prefab import run
+from ast import literal_eval
 import logging
 import sys
 import time
@@ -39,17 +40,390 @@ class ClusterConfig(object):
         return self.name
 
 
+class DerivedStatsProcessor(object):
+    def __init__(self, derived_stat_computers):
+        self._derived_stat_computers = derived_stat_computers
+
+
+    def begin_process(self, cluster_name):
+        for derived_stat_computer in self._derived_stat_computers:
+            derived_stat_computer.begin_process(cluster_name)
+
+
+    def select_stat(self, stat):
+        for derived_stat_computer in self._derived_stat_computers:
+            derived_stat_computer.select_stat(stat)
+
+
+    def end_process(self, cluster_name):
+        for derived_stat_computer in self._derived_stat_computers:
+            derived_stat_computer.end_process(cluster_name)
+
+
+    def stats(self):
+        for derived_stat_computer in self._derived_stat_computers:
+            yield derived_stat_computer
+
+
+class DerivedStatComputer(object):
+
+    def __init__(self, out_stat_name):
+        self._initialize()
+        self.out_stat_name = out_stat_name
+
+    def _initialize(self):
+        self._selected_stat_timestamps = {}
+        self._selected_stat_errors = {}
+
+
+    def begin_process(self, cluster_name):
+        self._initialize()
+
+
+    def end_process(self, cluster_name):
+        pass
+
+
+    def process(self, stat):
+        pass
+
+
+    def _choose_stat(self, stat):
+        LOG.debug("Choose stat: %s", stat.key)
+        try:
+            self._selected_stat_timestamps[stat.devid].append(long(stat.time))
+        except KeyError:
+            self._selected_stat_timestamps[stat.devid] = [long(stat.time)]
+
+
+    def _create_derived_stat(self, value, devid=0, error=None):
+        class DerivedStat(object):
+            """ Pretend to be a Stat returned by PAPI """
+            def __init__(self, key, val, node, timestamp, err):
+                self.key = key
+                self.value = val
+                self.devid = node
+                self.time = timestamp
+                self.error = err
+                self.error_code = \
+                        None if error is None else 1
+
+
+        return DerivedStat(
+                self.out_stat_name, value, devid,
+                self._get_timestamp_avg(devid), error)
+
+
+    def _get_timestamp_avg(self, devid):
+        if devid not in self._selected_stat_timestamps and devid == 0:
+            tot = 0
+            tot_count = 0
+            for node in self._selected_stat_timestamps:
+                tot += sum(self._selected_stat_timestamps[node])
+                tot_count += len(self._selected_stat_timestamps[node])
+            return long(tot / tot_count)
+        return long(sum(self._selected_stat_timestamps[devid])
+                / len(self._selected_stat_timestamps[devid]))
+
+
+class DerivedStatInput(object):
+    def __init__(self, stat_name, stat_fields=()):
+        self.name = stat_name
+        if stat_fields and len(stat_fields) > 0:
+            self._stat_fields = stat_fields
+        else:
+            self._stat_fields = None
+
+
+    def _lookup(self, stat_value, field, *fields):
+        if fields:
+            # if stat_value is not a dict or list then this will raise
+            # exception, which is what we want it to do.
+            if type(stat_value) == dict:
+                return self._lookup(stat_value.get(field, {}), *fields)
+            else:
+                return self._lookup(stat_value[field], *fields)
+        return stat_value.get(field)
+
+
+    def get_value(self, stat_value):
+        if self._stat_fields is not None:
+            # PAPI has a weird habit of putting stats that have only 1 value
+            # into a list. When that happens we just ignore the list
+            if type(stat_value) == list:
+                num_items = len(stat_value)
+                if num_items == 1:
+                    stat_value = stat_value[0]
+                elif num_items == 0:
+                    return None
+            return self._lookup(stat_value, *self._stat_fields)
+        return stat_value
+
+
+    @property
+    def full_name(self):
+        return self._get_full_name(self.name)
+
+
+    def _get_full_name(self, stat_name):
+        if self._stat_fields is not None:
+            full_name = stat_name
+            full_name += ":"
+            full_name += ":".join(self._stat_fields)
+        else:
+            full_name = stat_name
+        return full_name
+
+
+class ClusterCompositeStatComputer(DerivedStatComputer):
+    def __init__(self, input_stat, out_stat_name, operation):
+        super(ClusterCompositeStatComputer, self).__init__(out_stat_name)
+        self._input_stat = input_stat
+        self._operation = operation
+
+
+    def _initialize(self):
+        super(ClusterCompositeStatComputer, self)._initialize()
+        self._selected_stat_values = []
+
+
+    def select_stat(self, stat):
+        if stat.key == self._input_stat.name:
+            self._selected_stat_values.append(
+                    self._input_stat.get_value(stat.value))
+            self._choose_stat(stat)
+
+
+    def compute_derived_stat(self):
+        LOG.debug("CCSC %s(%s)",
+                str(self._operation.__name__), str(self._selected_stat_values))
+        return self._create_derived_stat(
+                self._operation(self._selected_stat_values))
+
+
+class EquationStatComputer(DerivedStatComputer):
+    def __init__(self, eq_func, input_stats, out_stat_name):
+        super(EquationStatComputer, self).__init__(out_stat_name)
+        self._eq_func = eq_func
+        self._num_func_args = len(input_stats)
+        self._input_stats = input_stats
+        self._input_stats_names = {}
+        self._input_stat_locations = {}
+        for index in range(0, self._num_func_args):
+            input_stat = self._input_stats[index]
+            # setup mapping from base stat name to input_stat
+            try:
+                # there might be multiple fields from a single stat with this
+                # name so we need to keep a list of input_stats
+                self._input_stats_names[input_stat.name].append(input_stat)
+            except KeyError:
+                self._input_stats_names[input_stat.name] = [input_stat]
+            # setup mapping from name to location(s) in the equation
+            try:
+                self._input_stat_locations[input_stat.full_name].append(index)
+            except KeyError:
+                self._input_stat_locations[input_stat.full_name] = [index]
+
+
+    def _initialize(self):
+        super(EquationStatComputer, self)._initialize()
+        self._selected_stat_values = {}
+        self._nodes = set()
+
+
+    def select_stat(self, stat):
+        # check if this stat is included in this equation
+        try:
+            input_stats = self._input_stats_names[stat.key]
+            # if there is an entry for this stat then it is part of my equation
+            self._choose_stat(stat)
+            self._nodes.add(stat.devid)
+        except KeyError:
+            return
+        for input_stat in input_stats:
+            try:
+                selected_stats_by_node = \
+                        self._selected_stat_values[input_stat.full_name]
+            except KeyError:
+                self._selected_stat_values[input_stat.full_name] = {}
+                selected_stats_by_node = \
+                        self._selected_stat_values[input_stat.full_name]
+
+            try:
+                selected_stats_by_node[stat.devid] = \
+                        input_stat.get_value(stat.value)
+            except KeyError:
+                selected_stats_by_node = {}
+                selected_stats_by_node[stat.devid] = \
+                        input_stat.get_value(stat.value)
+
+
+    def compute_derived_stats(self):
+        # return one derived stat per node that the selected stats were
+        # collected for.
+        derived_stats = []
+        for node in self._nodes:
+            # for each node build a tuple of the args to the equation
+            # by iterating through the intput stat names
+            func_args = [None] * self._num_func_args
+            for in_stat_name in self._input_stat_locations.keys():
+                stat_node = node
+                if in_stat_name.startswith("cluster.") is True:
+                    stat_node = 0 # this is a cluster stat
+                stat_value = self._get_stat_value(in_stat_name, stat_node)
+                in_arg_locations = self._input_stat_locations[in_stat_name]
+                for in_arg_loc in in_arg_locations:
+                    func_args[in_arg_loc] = stat_value
+            # if there is at least one non-None arg then convert the Nones to
+            # zero and try to do the computation. If all are None then skip it.
+            if self._null_to_zero(func_args) is False:
+                # failed to get this stat, so return error for it
+                derived_stat = \
+                        self._create_derived_stat(None, node,
+                                "Failed to get equation input for %s, " \
+                                "input params: %s." % \
+                                (self.out_stat_name, tuple(func_args)))
+            else:
+                try:
+                    func_args_tuple = tuple(func_args)
+                    LOG.debug("EQS [%s]=%s(%s)",
+                            str(node), str(self._eq_func), str(func_args_tuple))
+                    derived_stat_value = self._eq_func(*func_args_tuple)
+                    derived_stat = \
+                            self._create_derived_stat(derived_stat_value, node)
+                except Exception as exception:
+                    derived_stat = \
+                            self._create_derived_stat(None, node,
+                                error="Exception caught evaluating " \
+                                        "expression for %s, input " \
+                                        "params: %s, exception: %s" % \
+                                        (self.out_stat_name,
+                                            str(func_args_tuple),
+                                            str(exception)))
+            derived_stats.append(derived_stat)
+
+        return derived_stats
+
+
+    def _null_to_zero(self, func_args):
+        null_args = []
+        # since we don't know the type do some math to get zero in the correct
+        # data type from one of the non-zero values
+        zero = None
+        for aindex in range(0, self._num_func_args):
+            farg = func_args[aindex]
+            if farg is None:
+                null_args.append(aindex)
+            else:
+                zero = farg - farg
+
+        if len(null_args) == self._num_func_args:
+            # all the args are null so return False - we can't compute this
+            # equation
+            return False
+        # go back through and set null args to zero
+        for aindex in null_args:
+            func_args[aindex] = zero
+
+        return True
+
+
+    def _get_stat_value(self, stat_name, node):
+        try:
+            return self._selected_stat_values[stat_name][node]
+        except KeyError:
+            return None
+
+
+class PercentChangeStatComputer(DerivedStatComputer):
+    def __init__(self, input_stat, out_stat_name):
+        super(PercentChangeStatComputer, self).__init__(out_stat_name)
+        self._input_stat = input_stat
+        # per node/cluster value
+        self._cur_values = {}
+        self._prev_values = {}
+
+
+    def begin_process(self, cluster_name):
+        super(PercentChangeStatComputer, self).begin_process(cluster_name)
+        self._cur_cluster_name = cluster_name
+        self._cur_values = {}
+
+
+    def end_process(self, cluster_name):
+        super(PercentChangeStatComputer, self).end_process(cluster_name)
+        self._prev_values[cluster_name] = self._cur_values
+
+
+    def select_stat(self, stat):
+        if stat.key == self._input_stat.name:
+            self._cur_values[stat.devid] = \
+                    self._input_stat.get_value(stat.value)
+            self._choose_stat(stat)
+
+
+    def compute_derived_stats(self):
+        derived_stats = []
+        for node in self._cur_values:
+            try:
+                cur_value = self._cur_values[node]
+            except KeyError:
+                cur_value = None
+            if cur_value is None:
+                derived_stat = \
+                        self._create_derived_stat(None, node,
+                                error="Unable to determine current value " \
+                                        "of input stat: %s" \
+                                        % self._input_stat.full_name)
+            else:
+                try:
+                    prev_values = self._prev_values[self._cur_cluster_name]
+                    # TREAT no previous value as zero?
+                    prev_value = prev_values[node]
+                    LOG.debug("PCS [%s]=(%s /  %s) - 1",
+                            str(node), str(cur_value), str(prev_value))
+                    try:
+                        derived_stat_value = \
+                                (float(cur_value) / float(prev_value)) - 1
+                    except ZeroDivisionError:
+                        if cur_value == 0 or cur_value == 0.0:
+                            # prev_value and cur_value == 0
+                            derived_stat_value = 0.0
+                        else:
+                            derived_stat_value = \
+                                    (float(prev_value) / float(cur_value)) - 1
+                            derived_stat_value *= -1.0
+                    derived_stat_value *= 100.0
+                except KeyError:
+                    # no previous value will cause a KeyError
+                    # so return 0% change
+                    derived_stat_value = 0.0
+                derived_stat = \
+                        self._create_derived_stat(derived_stat_value, node)
+            derived_stats.append(derived_stat)
+
+        return derived_stats
+
+
 class StatsConfig(object):
     def __init__(self, cluster_configs, stats, update_interval):
         self.cluster_configs = cluster_configs
         self.stats = stats
         self.update_interval = update_interval
+        self.cluster_composite_stats = []
+        self.equation_stats = []
+        self.pct_change_stats = []
+        self.final_equation_stats = []
 
 
 class StatSet(object):
     def __init__(self):
         self.cluster_configs = []
         self.stats = set()
+        self.cluster_composite_stats = []
+        self.equation_stats = []
+        self.pct_change_stats = []
+        self.final_equation_stats = []
 
 
 class UpdateInterval(object):
@@ -73,14 +447,21 @@ class IsiDataInsightsDaemon(run.RunDaemon):
         self._update_intervals = []
         self._stats_processor = None
         self._stats_processor_args = None
+        self._process_stats_func = None
 
 
     def set_stats_processor(self, stats_processor, processor_args):
-        if hasattr(stats_processor, 'process') is False:
-            raise AttributeError(
-                    "Results processor module has no process() function.")
         self._stats_processor = stats_processor
         self._stats_processor_args = processor_args
+        if hasattr(stats_processor, 'process_stat') is True:
+            self._process_stats_func = self._process_stats_with_derived_stats
+            self._init_derived_stats_processor()
+        elif hasattr(stats_processor, 'process') is True:
+            self._process_stats_func = self._process_all_stats
+        else:
+            raise AttributeError(
+                    "Results processor module has no process() or " \
+                            "process_stat() function.")
         # start the stats processor module
         if hasattr(self._stats_processor, 'start') is True:
             # need to start the processor now before the process is daemonized
@@ -88,6 +469,18 @@ class IsiDataInsightsDaemon(run.RunDaemon):
             # starting.
             LOG.info("Starting stats processor.")
             self._stats_processor.start(self._stats_processor_args)
+
+
+    def _init_derived_stats_processor(self):
+        # if the stats processor doesn't define begin_process or end_process,
+        # then add a noop version so we don't have to check each time we
+        # process stats
+        def noop(cluster_name):
+            pass
+        if hasattr(self._stats_processor, 'begin_process') is False:
+            self._stats_processor.begin_process = noop
+        if hasattr(self._stats_processor, 'end_process') is False:
+            self._stats_processor.end_process = noop
 
 
     def add_stats(self, stats_config):
@@ -109,11 +502,23 @@ class IsiDataInsightsDaemon(run.RunDaemon):
         # update interval's stat set.
         for cluster in stats_config.cluster_configs:
             if cluster not in stat_set.cluster_configs:
+                # TODO this is a bug - this causes these stats to be queried on
+                # all clusters in this update interval, not just the clusters
+                # defined in this stats_config
                 stat_set.cluster_configs.append(cluster)
 
         # add the new stats to the stat set
         for stat_name in stats_config.stats:
             stat_set.stats.add(stat_name)
+
+        stat_set.cluster_composite_stats.extend(
+                stats_config.cluster_composite_stats)
+
+        stat_set.equation_stats.extend(stats_config.equation_stats)
+
+        stat_set.pct_change_stats.extend(stats_config.pct_change_stats)
+
+        stat_set.final_equation_stats.extend(stats_config.final_equation_stats)
 
 
     def get_stat_set_count(self):
@@ -194,16 +599,38 @@ class IsiDataInsightsDaemon(run.RunDaemon):
                 update_interval.last_update = cur_time
                 # add the stats from stat set to their respective cluster_stats
                 cur_stat_set = self._stat_sets[update_interval.interval]
-                for stat_name in cur_stat_set.stats:
-                    for cluster in cur_stat_set.cluster_configs:
-                        try:
-                            cluster_stat_set = cluster_stats[cluster]
-                        except KeyError:
-                            cluster_stats[cluster] = cluster_stat_set = set()
+                for cluster in cur_stat_set.cluster_configs:
+                    try:
+                        (cluster_stat_set,
+                                cluster_composite_stats,
+                                equation_stats,
+                                pct_change_stats,
+                                final_equation_stats) = \
+                                        cluster_stats[cluster]
+                        cluster_composite_stats.extend(
+                                cur_stat_set.cluster_composite_stats)
+                        equation_stats.extend(
+                                cur_stat_set.equation_stats)
+                        pct_change_stats.extend(
+                                cur_stat_set.pct_change_stats)
+                        final_equation_stats.extend(
+                                cur_stat_set.final_equation_stats)
+                    except KeyError:
+                        cluster_stat_set = set()
+                        cluster_stats[cluster] = (
+                                cluster_stat_set,
+                                cur_stat_set.cluster_composite_stats,
+                                cur_stat_set.equation_stats,
+                                cur_stat_set.pct_change_stats,
+                                cur_stat_set.final_equation_stats)
+
+                    for stat_name in cur_stat_set.stats:
                         cluster_stat_set.add(stat_name)
 
         # now we have a unique list of clusters to query, so query them
-        for cluster, stats in cluster_stats.iteritems():
+        for cluster, (stats,
+                composite_stats, eq_stats,
+                pct_change_stats, final_eq_stats) in cluster_stats.iteritems():
             LOG.debug("Querying cluster %s %f", cluster.name, cluster.version)
             LOG.debug("Querying stats %d.", len(stats))
             stats_client = \
@@ -214,15 +641,176 @@ class IsiDataInsightsDaemon(run.RunDaemon):
                 if cluster.version >= 8.0:
                     results = stats_client.query_stats(stats)
                 else:
-                    results = []
-                    for stat in stats:
-                        result = stats_client.query_stat(stat)
-                        results.extend(result)
-
+                    results = \
+                            self._v7_2_stat_query_result_generator(
+                                    stats, stats_client)
             except (urllib3.exceptions.HTTPError,
                     cluster.isi_sdk.rest.ApiException) as http_exc:
                 LOG.error("Failed to query stats from cluster %s, exception "\
                           "raised: %s", cluster.name, str(http_exc))
                 continue
-            # process the results
-            self._stats_processor.process(cluster.name, results)
+
+
+            composite_stats_processor = \
+                    DerivedStatsProcessor(composite_stats)
+            equation_stats_processor = \
+                    DerivedStatsProcessor(eq_stats)
+            pct_change_stats_processor = \
+                    DerivedStatsProcessor(pct_change_stats)
+            final_equation_stats_processor = \
+                    DerivedStatsProcessor(final_eq_stats)
+            derived_stats_processors = \
+                    (composite_stats_processor,
+                            equation_stats_processor,
+                            pct_change_stats_processor,
+                            final_equation_stats_processor)
+            # calls either _process_all_stats or
+            # _process_stats_with_derived_stats depending on whether or not the
+            # _stats_processor has a process_stat function or just a process
+            # function. The latter requires the process_stat function.
+            self._process_stats_func(
+                    cluster.name, results, derived_stats_processors)
+
+
+    def _v7_2_stat_query_result_generator(self, stats, stats_client):
+        for stat in stats:
+            result = stats_client.query_stat(stat)
+            yield result[0]
+
+
+    def _process_all_stats(self, *args):
+        cluster_name = args[0]
+        results = args[1]
+        # the initial version of the stats processor plugin processed all stats
+        # at once, this function allows backwards compatibility, but derived
+        # stats are not supported
+        self._stats_processor.process(cluster_name, results)
+
+
+    def _process_stats_with_derived_stats(
+            self, cluster_name, stats_query_results, derived_stats):
+        LOG.debug("Processing stat results on %s", cluster_name)
+        self._stats_processor.begin_process(cluster_name)
+        (cluster_composite_stats,
+                equation_stats,
+                pct_change_stats,
+                final_equation_stats) = derived_stats
+        cluster_composite_stats.begin_process(cluster_name)
+        equation_stats.begin_process(cluster_name)
+        pct_change_stats.begin_process(cluster_name)
+        final_equation_stats.begin_process(cluster_name)
+        # process the results
+        for stat in stats_query_results:
+            # check if the stat query returned an error
+            if stat.error is not None:
+                LOG.warning("Query for stat: '%s' on '%s', returned error: '%s'.",
+                        str(stat.key), cluster_name, str(stat.error))
+                continue
+            self._prep_stat(stat)
+            # let stats processor process it
+            self._stats_processor.process_stat(cluster_name, stat)
+            # allow derived stats to select/use this stat
+            cluster_composite_stats.select_stat(stat)
+            equation_stats.select_stat(stat)
+            pct_change_stats.select_stat(stat)
+            final_equation_stats.select_stat(stat)
+
+        LOG.debug("Processing composite stats on %s", cluster_name)
+        for composite_stat in cluster_composite_stats.stats():
+            # composite stats always return only one derived stat
+            derived_stat = composite_stat.compute_derived_stat()
+            if derived_stat.error is not None:
+                LOG.warning("Cluster node composite stat: " \
+                        "'%s' on '%s', returned error: '%s'.",
+                        str(derived_stat.key),
+                        cluster_name,
+                        str(derived_stat.error))
+                continue
+            LOG.debug("ClusterCompositeStat[%s]=%s",
+                    derived_stat.key, str(derived_stat.value))
+            # let stats processor process it
+            self._stats_processor.process_stat(cluster_name, derived_stat)
+            # allow derived stats to select/use this stat
+            equation_stats.select_stat(derived_stat)
+            pct_change_stats.select_stat(derived_stat)
+            final_equation_stats.select_stat(derived_stat)
+
+        LOG.debug("Processing equation stats on %s", cluster_name)
+        for eq_stat in equation_stats.stats():
+            # equation stats might produce more than one derived stat,
+            # potentially one stat per node
+            derived_stats = eq_stat.compute_derived_stats()
+            for derived_stat in derived_stats:
+                if derived_stat.error is not None:
+                    LOG.warning("Equation computed stat: " \
+                            "'%s' on '%s', returned error: '%s'.",
+                        str(derived_stat.key),
+                        cluster_name,
+                        str(derived_stat.error))
+                    continue
+                LOG.debug("EquationStat[%s]=%s",
+                        derived_stat.key, str(derived_stat.value))
+                # let stats processor process them
+                self._stats_processor.process_stat(cluster_name, derived_stat)
+                # allow derived stats to select/use this stat
+                pct_change_stats.select_stat(derived_stat)
+                final_equation_stats.select_stat(derived_stat)
+
+        LOG.debug("Processing percent change stats on %s", cluster_name)
+        for pct_change_stat in pct_change_stats.stats():
+            # percent change stats might produce more than one derived stat,
+            # potentially one stat per node
+            derived_stats = pct_change_stat.compute_derived_stats()
+            for derived_stat in derived_stats:
+                if derived_stat.error is not None:
+                    LOG.warning("Percent change stat: " \
+                            "'%s' on '%s', returned error: '%s'.",
+                        str(derived_stat.key),
+                        cluster_name,
+                        str(derived_stat.error))
+                    continue
+                LOG.debug("PercentChangeStat[%s]=%s",
+                        derived_stat.key, str(derived_stat.value))
+                # let stats processor process it
+                self._stats_processor.process_stat(cluster_name, derived_stat)
+                # allow derived stats to select/use this stat
+                final_equation_stats.select_stat(derived_stat)
+
+        LOG.debug("Processing final equation stats on %s", cluster_name)
+        for eq_stat in final_equation_stats.stats():
+            # equation stats might produce more than one derived stat,
+            # potentially one stat per node
+            derived_stats = eq_stat.compute_derived_stats()
+            for derived_stat in derived_stats:
+                if derived_stat.error is not None:
+                    LOG.warning("Final equation computed stat: " \
+                            "'%s' on '%s', returned error: '%s'.",
+                        str(derived_stat.key),
+                        cluster_name,
+                        str(derived_stat.error))
+                    continue
+                LOG.debug("FinalEquationStat[%s]=%s",
+                        derived_stat.key, str(derived_stat.value))
+                # let stats processor process them
+                self._stats_processor.process_stat(cluster_name, derived_stat)
+
+        self._stats_processor.end_process(cluster_name)
+        cluster_composite_stats.end_process(cluster_name)
+        equation_stats.end_process(cluster_name)
+        pct_change_stats.end_process(cluster_name)
+        final_equation_stats.end_process(cluster_name)
+
+
+    def _prep_stat(self, stat):
+        try:
+            # the stat value's data type is variable depending on the key so
+            # use literal_eval() to convert it to the correct type
+            eval_value = literal_eval(stat.value)
+            # convert tuples to a list for simplicity
+            if type(eval_value) == tuple:
+                stat.value = list(eval_value)
+            else:
+                stat.value = eval_value
+        except Exception: # if literal_eval throws an exception
+            # then just leave it as string value
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pip >= 8.0.2
 urllib3 >= 1.13.1
 isi_sdk_8_0 >= 0.1.2
 isi_sdk_7_2 >= 0.1.2
+Equation >= 1.2.01


### PR DESCRIPTION
Added logic for deriving stats by compositing node stats, computing a
custom equations, computing percent change in stats, and finally
computing custom equations from any of the previously derived stats.

Includes ability to address specific fields of stat value for derived
stats.  If the value of a particular stat key is a dict or list then
you can now use a specific field or index in a derived stat computation.
Note that if the value is a list with only a single dict element then
you can address a field of the dict directly with the field name or by
using the 0 index.

Added config file parsing for the derived stats.

And added Equations to the requirements.txt.