### PR TITLE
Made Disk Write use cluster.disk.bytes.in.rate

### DIFF
--- a/grafana_cluster_detail_dashboard.json
+++ b/grafana_cluster_detail_dashboard.json
@@ -2848,7 +2848,7 @@
                 }
               ],
               "hide": false,
-              "measurement": "cluster.disk.bytes.out.rate",
+              "measurement": "cluster.disk.bytes.in.rate",
               "policy": "default",
               "query": "SELECT mean(\"value\") FROM \"cluster.net.ext.packets.in.rate\" WHERE \"cluster\" =~ /$cluster$/ AND $timeFilter GROUP BY time($interval) fill(null)",
               "refId": "F",


### PR DESCRIPTION
The Cluster Detail dashboard's "Cluster Network, File System, and Disk
Throughput" graph's "Disk Write" line was incorrectly displaying the
cluster.disk.bytes.out.rate instead of the cluster.disk.bytes.in.rate.