### PR TITLE
Force the stats to be named as they are in the config file

### DIFF
--- a/example_isi_data_insights_d.cfg
+++ b/example_isi_data_insights_d.cfg
@@ -44,7 +44,7 @@ active_stat_groups: cluster_cpu_stats
 # of the minimum interval, which defaults to 30 seconds, is to prevent
 # the daemon's queries from putting too much stress on the cluster.
 # The default value is 30 seconds.
-# min_update_interval_override = 15
+# min_update_interval_override: 15
 
 [cluster_cpu_stats]
 # The clusters (optional) param defines a list of clusters specific to this
@@ -75,13 +75,12 @@ stats: node.clientstats.active.ftp
     node.clientstats.active.http
     node.clientstats.active.lsass_out
     node.clientstats.active.jobd
-    node.clientstats.active.nfs3
+    node.clientstats.active.nfs
     node.clientstats.active.nfs4
     node.clientstats.active.nlm
     node.clientstats.active.papi
     node.clientstats.active.siq
     node.clientstats.active.cifs
-    node.clientstats.active.smb1
     node.clientstats.active.smb2
     node.clientstats.connected.ftp
     node.clientstats.connected.hdfs


### PR DESCRIPTION
Previously, if the stat name in the config file was an alias then it
would get re-named back to the "real" name at config time. Now it keeps
its original name from the config file regardless of whether or not it
is an alias.

This means that if you upgrade to this revision and you are using the
provided example_isi_data_insights_d.cfg as your config file and the
provided Grafana dashboards, then you need to change the name of the
node.clientstats.active.nfs3 stat to node.clientstats.active.nfs because
even though it was named "nfs3" it was actually getting inserted into
InfluxDB as "nfs" because that is the "real" name of that particular
stat. So in order for your data to be continuous, you'll need to fix
your config file (see the updates to example_isi_data_insights_d.cfg
for reference).