### PR TITLE
Enable parallel queries by leveraging gevent

### DIFF
--- a/isi_data_insights_d.py
+++ b/isi_data_insights_d.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python
+
+# Have to do this before importing the other libs
+# The noqa comment prevents spurious E402 flake8 errors
+# The documentation for monkey explicitly requires patching to be
+# performed as early as possible BEFORE other imports
+from gevent import monkey
+monkey.patch_all()  # noqa
+
 import sys
 
 from isi_data_insights_config import parse_cli, \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ urllib3 >= 1.13.1
 isi_sdk_8_0 >= 0.1.2
 isi_sdk_7_2 >= 0.1.2
 Equation >= 1.2.01
+gevent >= 1.2.1


### PR DESCRIPTION
Minimal changes to allow all of the stat queries for multiple clusters
to execute in parallel. Obviously the GIL still means that there can
only be one active thread but since the data collector spends most of
the time waiting for a response from the various clusters or sleeping,
this simplistic approach actually works well in practice.

Internally at Isilon, it's easily able to keep up with monitoring the
statistics for 24 separate clusters every 30 seconds.