### PR TITLE
Fix 7.2 node stat queries

### DIFF
--- a/isi_data_insights_daemon.py
+++ b/isi_data_insights_daemon.py
@@ -655,7 +655,7 @@ class IsiDataInsightsDaemon(run.RunDaemon):
                 results = stats_client.query_stats(stats)
             else:
                 results = \
-                        self._v7_2_stat_query_result_generator(
+                        self._v7_2_multistat_query(
                                 stats, stats_client)
         except (urllib3.exceptions.HTTPError,
                 cluster.isi_sdk.rest.ApiException) as http_exc:
@@ -694,10 +694,11 @@ class IsiDataInsightsDaemon(run.RunDaemon):
                 cluster.name, results, derived_stats_processors)
 
 
-    def _v7_2_stat_query_result_generator(self, stats, stats_client):
+    def _v7_2_multistat_query(self, stats, stats_client):
+        result = []
         for stat in stats:
-            result = stats_client.query_stat(stat)
-            yield result[0]
+            result.extend(stats_client.query_stat(stat))
+        return result
 
 
     def _process_all_stats(self, *args):


### PR DESCRIPTION
Code was only returning the first element which was wrong for node-based stats. Trying to "fix" the generator by returning the whole list doesn't work either. You end up with
[[first list of stats], [second list of stats], ...]
whereas what you need is
[single level list of individual stat results]
Convert generator back to simple function that aggregates and returns a single list.
Fixes issue #41.
Compare to f121783c73ab82716f7594d8880b2d00b9171642