### PR TITLE
Remove node.memory.cache from stats

### DIFF
--- a/example_isi_data_insights_d.cfg
+++ b/example_isi_data_insights_d.cfg
@@ -122,7 +122,6 @@ stats: node.cpu.throttling
   node.load.15min
   node.memory.used
   node.memory.free
-  node.memory.cache
   node.open.files
  
 [node_disk_stats]


### PR DESCRIPTION
This statistic hasn't given usable information for a long time and was
removed in recent OneFS releases causing an error on retrieval.
Fixes #66.