### PR TITLE
Remove node.cpu.throttling

### DIFF
--- a/example_isi_data_insights_d.cfg
+++ b/example_isi_data_insights_d.cfg
@@ -116,8 +116,7 @@ stats: ifs.bytes.in.rate
  
 [node_load_stats]
 update_interval: *
-stats: node.cpu.throttling
-  node.load.1min
+stats: node.load.1min
   node.load.5min
   node.load.15min
   node.memory.used


### PR DESCRIPTION
This statistic is not available across all platforms and releases and
causes startup failures when unavailable.
Fixes #69