### PR TITLE
Use python3 venv module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Our virtual environments
+.venv
+.venv3
+
+# Development environment stuff
+.vscode

--- a/setup_venv3.sh
+++ b/setup_venv3.sh
@@ -4,12 +4,10 @@ set -e
 
 venv_path=".venv3"
 
-pip install --user virtualenv
-
-virtualenv -p python3 $venv_path
+python3 -m venv $venv_path
 
 . $venv_path/bin/activate
-pip3 install -r requirements.txt
+pip install -r requirements.txt
 
 echo
 echo "Isilon Data Insights Connector virtual environment setup at $venv_path."


### PR DESCRIPTION
As suggested by @tucked, switch to using the builtin Python virtualenv
code (everybody should be running something newer than 3.3 at this
point). Add a bunch of additional filters to .gitignore to ignore our
local virtualenvs and other IDE cruft.