### PR TITLE
Fix tag selection logic.

### DIFF
--- a/influxdb_plugin.py
+++ b/influxdb_plugin.py
@@ -3,6 +3,7 @@ from builtins import input
 from builtins import str
 from builtins import range
 from builtins import object
+from future.utils import string_types
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBServerError, InfluxDBClientError
 
@@ -164,7 +165,7 @@ def _process_stat_dict(stat_value, fields, tags, prefix=""):
     for key, value in stat_value.items():
         value_type = type(value)
         field_name = prefix + key
-        if (value_type == str) or (key[-2:] == "id" and value_type == int):
+        if isinstance(value, string_types) or (key[-2:] == "id" and value_type == int):
             tags[field_name] = value
         elif value_type == list:
             list_prefix = field_name + SUB_KEY_SEPARATOR


### PR DESCRIPTION
The latest Isilon SDK now returns strings as unicode instead of str in
Python 2 which breaks the logic that decides whether a component of the
returned statistic is a field or a tag. While we're still supporting
both use future.utils.string_types to handle this.

Fixes issue #95.