### PR TITLE
Fix pylint complaint (add default value)

### DIFF
--- a/isi_data_insights_daemon.py
+++ b/isi_data_insights_daemon.py
@@ -139,7 +139,7 @@ class DerivedStatInput(object):
         else:
             self._stat_fields = None
 
-    def _lookup(self, stat_value, field, *fields):
+    def _lookup(self, stat_value, field=None, *fields):
         if fields:
             # if stat_value is not a dict or list then this will raise
             # exception, which is what we want it to do.


### PR DESCRIPTION
The code is using the language arg unpacking rather than expicitly doing
it, and recursively calling the class method with the wrong number of
arguments (relying on the unpacking). Ideally, the code should do this
explicitly but as a workaround, add a default to prevent pylint
confusion.

Fixes issue #93