### PR TITLE
Update pip and setuptools in venv

### DIFF
--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -9,6 +9,7 @@ pip install --user virtualenv
 virtualenv $venv_path
 
 . $venv_path/bin/activate
+pip install -U pip setuptools
 pip install -r requirements.txt
 
 echo


### PR DESCRIPTION
The distro-supplied versions are so old that they break on things like
the gevent wheel. Update them before trying to pull in any of our
dependent packages. Fixes #104.