### PR TITLE
Fixing missing influxdb_username/password if no auth

### DIFF
--- a/influxdb_plugin.py
+++ b/influxdb_plugin.py
@@ -50,6 +50,8 @@ def start(argv):
     influxdb_name = argv[2]
     influxdb_ssl = False
     influxdb_verifyssl = False
+    influxdb_username = "root"
+    influxdb_password = "root"
 
     if len(argv) > 3:
         if argv[3] == "auth":


### PR DESCRIPTION
In case of no auth used for influx plugin
`influxdb_username` and `influxdb_password` vars are not
initilized, which is causing Python exception.

This will assign default values of "root:root" and update them
in case of auth used.