### PR TITLE
Fix for prometheus_plugin and requirements.

### DIFF
--- a/prometheus_plugin.py
+++ b/prometheus_plugin.py
@@ -94,7 +94,7 @@ def _process_dict(tags, basekey, statdict):
     all number values in the dict are metrics. But it contains text members
     and fields named with 'id': Those are filtered out as tags
     '''
-    for k in statdict.keys():
+    for k in list(statdict.keys()):
         if isinstance(statdict[k], string_types) or (k[-2:] == 'id' and isinstance(statdict[k], int)):
             tags[k] = statdict[k]
             del statdict[k]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Equation >= 1.2.01
 gevent >= 1.2.1
 future >= 0.18.0
 configparser >= 0.4.0
+prometheus_client == 0.12.0


### PR DESCRIPTION
I got this issue with running prometheus_plugin and fix it.

```
Configured stat set:
        Clusters: [isilon01]
        Update Interval: 300
        Stat Keys: {'ifs.bytes.free', 'ifs.bytes.avail', 'ifs.percent.avail', 'ifs.bytes.total', 'ifs.percent.used', 'ifs.bytes.used', 'ifs.percent.free'}
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
  File "/isilon/isi_data_insights_daemon.py", line 702, in _query_and_process_stats1
    self._process_stats_func(cluster.name, results, derived_stats_processors)
  File "/isilon/isi_data_insights_daemon.py", line 746, in _process_stats_with_derived_stats
    self._stats_processor.process_stat(cluster_name, stat)
  File "/isilon/prometheus_plugin.py", line 76, in process_stat
    _process_list(tags, stat.key, stat.value)
  File "/isilon/prometheus_plugin.py", line 88, in _process_list
    _process_dict(tags, basekey, elem)
  File "/isilon/prometheus_plugin.py", line 97, in _process_dict
    for k in statdict.keys():
RuntimeError: dictionary changed size during iteration
2021-12-27T14:37:38Z <Greenlet at 0x7fb77e858260: <bound method IsiDataInsightsDaemon._query_and_process_stats1 of <isi_data_insights_daemon.IsiDataInsightsDaemon object at 0x7fb781767a00>>(isilon01, {'node.clientstats.active.siq', 'cluster.protostat, [], [], [], [], False)> failed with RuntimeError  
```

Also my PR contains requirements.txt list changes: added prometheus_client
